### PR TITLE
S45: success.html — bound the loading state with a 10s timeout fallback

### DIFF
--- a/ssd/success.html
+++ b/ssd/success.html
@@ -69,24 +69,40 @@
         </div>
     </div>
     <script>
-        var params = new URLSearchParams(window.location.search);
-        var sessionId = params.get('session_id');
-        if (sessionId) {
+        (function () {
+            var params = new URLSearchParams(window.location.search);
+            var sessionId = params.get('session_id');
+            var keyDisplay = document.getElementById('key-display');
+            var settled = false;
+
+            function setKeyText(text) {
+                if (settled) return;
+                settled = true;
+                keyDisplay.childNodes[1].textContent = text;
+            }
+            function showFallback() {
+                setKeyText("We're processing your purchase. Your key will arrive by email within 2 minutes. If you don't see it, email fred@hazeydata.ai with your Stripe receipt and I'll send it directly.");
+            }
+
+            if (!sessionId) { showFallback(); return; }
+
+            var timeoutId = setTimeout(showFallback, 10000);
+
             fetch('https://api.hazeydata.ai/ssd/key-reveal?session_id=' + encodeURIComponent(sessionId))
-                .then(function(r) { return r.json(); })
-                .then(function(data) {
-                    if (data.api_key) {
-                        document.getElementById('key-display').childNodes[1].textContent = data.api_key;
+                .then(function (r) { return r.json().then(function (data) { return { status: r.status, data: data }; }); })
+                .then(function (resp) {
+                    clearTimeout(timeoutId);
+                    if (resp.data && resp.data.api_key) {
+                        setKeyText(resp.data.api_key);
                     } else {
-                        document.getElementById('key-display').childNodes[1].textContent = 'Your key will be emailed to you shortly.';
+                        showFallback();
                     }
                 })
-                .catch(function() {
-                    document.getElementById('key-display').childNodes[1].textContent = 'Your key will be emailed to you shortly.';
+                .catch(function () {
+                    clearTimeout(timeoutId);
+                    showFallback();
                 });
-        } else {
-            document.getElementById('key-display').childNodes[1].textContent = 'Your key will be emailed to you shortly.';
-        }
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add a 10s `setTimeout` fallback to `ssd/success.html` so the API-key loading state is always bounded — even if the backend fetch hangs or the worker returns an unexpected response shape.
- Better fallback copy: actionable instructions instead of vague "emailed shortly."
- IIFE + `settled` flag so timeout + fetch race each other cleanly.

Companion worker fix: `data-hub#dino/s45-post-purchase-delivery-fix` (already deployed to production).

## Why
Alex Dossey, our first paying SSD customer, reported the success page hung on "Loading your API key..." after his purchase. The original code had no upper bound on the loading state — if `fetch` never resolved (or `r.json()` threw without `.catch` firing) the user saw indefinite "Loading…".

## Test plan
- [ ] Fred runs a real test purchase against production
- [ ] Key visible on success page within ~5 seconds (worker fast path)
- [ ] If reveal isn't ready yet (race), fallback fires at 10s with actionable copy
- [ ] Click-to-copy still works on the key box

🤖 Generated with [Claude Code](https://claude.com/claude-code)