### PR TITLE
S45: success.html DOM bug — fallback text was going to copy-hint span

### DIFF
--- a/ssd/success.html
+++ b/ssd/success.html
@@ -40,9 +40,9 @@
         <h1>Welcome to the School Schedule Database!</h1>
         <p>Your subscription is active and your API key is ready.</p>
 
-        <div class="key-box" id="key-display" onclick="navigator.clipboard.writeText(this.textContent).then(function(){document.querySelector('.copy-hint').textContent='Copied!'})">
+        <div class="key-box" id="key-display" onclick="copyKey()">
             <span class="copy-hint">Click to copy</span>
-            Loading your API key...
+            <span id="key-text">Loading your API key...</span>
         </div>
         <p><strong>Save this key now — it's shown only once.</strong> We store only a hash and cannot recover it for you.</p>
 
@@ -69,16 +69,25 @@
         </div>
     </div>
     <script>
+        function copyKey() {
+            var keyText = document.getElementById('key-text').textContent;
+            // Don't copy the loading placeholder or the fallback message
+            if (keyText.indexOf('ssd_live_') !== 0 && keyText.indexOf('ssd_trial_') !== 0) return;
+            navigator.clipboard.writeText(keyText).then(function () {
+                document.querySelector('.copy-hint').textContent = 'Copied!';
+            });
+        }
+
         (function () {
             var params = new URLSearchParams(window.location.search);
             var sessionId = params.get('session_id');
-            var keyDisplay = document.getElementById('key-display');
+            var keyTextEl = document.getElementById('key-text');
             var settled = false;
 
             function setKeyText(text) {
                 if (settled) return;
                 settled = true;
-                keyDisplay.childNodes[1].textContent = text;
+                keyTextEl.textContent = text;
             }
             function showFallback() {
                 setKeyText("We're processing your purchase. Your key will arrive by email within 2 minutes. If you don't see it, email fred@hazeydata.ai with your Stripe receipt and I'll send it directly.");


### PR DESCRIPTION
## Summary
- Fix the DOM-targeting bug introduced by PR #12. `setKeyText` was writing into `childNodes[1]` — which is the `<span class="copy-hint">`, not the loading-text node — so the fallback message replaced "Click to copy" and the original "Loading your API key…" text remained, stacking both on screen.
- Wrap the loading text in `<span id="key-text">` so the script targets it unambiguously.
- Replace inline `onclick` with `copyKey()` that copies *only* `#key-text` content (was copying the entire box including "Click to copy" label).
- `copyKey()` no-ops if text doesn't start with `ssd_live_` / `ssd_trial_` — clicking during loading or on the fallback message no longer copies placeholder text.

## Verify after merge + Cloudflare Pages redeploy
- [ ] `https://hazeydata.ai/ssd/success.html` (no params) → shows ONLY the fallback message in the key-box, no "Loading…" text
- [ ] `https://hazeydata.ai/ssd/success.html?session_id=fake_dino_test_value` → key-reveal returns 202 `{status: "pending"}`, fallback fires, only one message visible
- [ ] Hard-reload (Cmd+Shift+R) to bypass Pages cache before checking

🤖 Generated with [Claude Code](https://claude.com/claude-code)