### PR TITLE
Issue #112 — correct the SSD pages: cadence, counts, API example, coverage claims

### DIFF
--- a/ssd.html
+++ b/ssd.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>School Schedule Database — HazeyData.ai</title>
-    <meta name="description" content="Complete US school calendar dataset. 13,400+ districts, 46M+ students. Start/end dates, spring break, winter break, summer schedules. API access.">
+    <meta name="description" content="Complete US school calendar dataset. 13,679 districts, 44.7M students. Start/end dates, spring break, winter break, summer schedules. API access.">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icon-32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/icon-180.png">
     <meta name="theme-color" content="#0a1628">
@@ -13,15 +13,15 @@
     <!-- Open Graph -->
     <meta property="og:type" content="product">
     <meta property="og:url" content="https://hazeydata.ai/ssd.html">
-    <meta property="og:title" content="School Schedule Database — 13,400+ US Districts">
-    <meta property="og:description" content="Complete US school calendar dataset. 13,400+ districts, 46M+ students. Start/end dates, spring break, winter break, summer schedules. Structured API access.">
+    <meta property="og:title" content="School Schedule Database — 13,679 US Districts">
+    <meta property="og:description" content="Complete US school calendar dataset. 13,679 districts, 44.7M students. Start/end dates, spring break, winter break, summer schedules. Structured API access.">
     <meta property="og:image" content="https://hazeydata.ai/assets/banner.jpg">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@disneystatswhiz">
-    <meta name="twitter:title" content="School Schedule Database — 13,400+ US Districts">
-    <meta name="twitter:description" content="Complete US school calendar dataset. 13,400+ districts covering 46M+ students. API access for spring break, winter break, start/end dates.">
+    <meta name="twitter:title" content="School Schedule Database — 13,679 US Districts">
+    <meta name="twitter:description" content="Complete US school calendar dataset. 13,679 districts covering 44.7M students. API access for spring break, winter break, start/end dates.">
     <meta name="twitter:image" content="https://hazeydata.ai/assets/banner.jpg">
 
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -581,10 +581,10 @@
     <section class="hero">
         <div class="hero-badge">
             <span class="dot"></span>
-            Actively Growing — Updated Daily
+            Actively Growing — Three School Years
         </div>
         <h1>The School Schedule Database</h1>
-        <p>A comprehensive dataset of US school calendars. 13,400+ districts, 46M+ students. Start dates, end dates, spring break, winter break, summer schedules — structured and ready for analysis.</p>
+        <p>A comprehensive dataset of US school calendars. 13,679 districts, 44.7M students. Start dates, end dates, spring break, winter break, summer schedules — structured and ready for analysis.</p>
         <p style="font-size: 14px; color: var(--accent); margin-top: 8px;">
             <a href="/ssd/ssd_sample_top100.csv" download style="color: var(--accent-light); text-decoration: none; border-bottom: 1px solid rgba(74,144,164,0.3);">
                 ⬇️ Download free sample (top 100 districts, 9.5M students)
@@ -592,11 +592,11 @@
         </p>
         <div class="hero-stats">
             <div class="hero-stat">
-                <div class="val" id="stat-districts">13,400+</div>
+                <div class="val" id="stat-districts">13,679</div>
                 <div class="lbl">Districts</div>
             </div>
             <div class="hero-stat">
-                <div class="val">46M+</div>
+                <div class="val">44.7M</div>
                 <div class="lbl">Students</div>
             </div>
             <div class="hero-stat">
@@ -656,7 +656,7 @@
             <ul>
                 <li class="good"><strong>Big districts are solid.</strong> Florida, Texas, Georgia, North Carolina — the major states have 77-100% confirmation rates. If your use case is weighted by student volume, you're in great shape.</li>
                 <li class="good"><strong>Every row has data.</strong> Even unconfirmed districts have reasonable state-median estimates. You won't hit nulls.</li>
-                <li class="mid"><strong>Confidence is labeled.</strong> Every row has a <code>confidence</code> field — "confirmed" or "medium". Filter by confidence to suit your risk tolerance.</li>
+                <li class="mid"><strong>Confidence is labeled.</strong> Every row has a <code>source_method</code> field. Filter on <code>source_method</code>. The evidence methods are <code>observed</code>, <code>r1_extract_driver</code>, <code>official_calendar_pdf_verified</code> and <code>human_anchor_email</code>; every other method is an estimate. Do not filter on <code>confidence</code> &mdash; it does not separate evidence from estimate, and the highest confidence values in the store belong to estimate methods.</li>
                 <li class="mid"><strong>Small districts are the gap.</strong> Districts under 2,000 students make up most of the unconfirmed rows. If you're modeling national-scale patterns, the impact is minimal.</li>
                 <li class="low"><strong>This is 2025-2026 only.</strong> We don't yet have multi-year historical data. That's planned for future releases.</li>
             </ul>
@@ -777,7 +777,7 @@
             </tbody>
         </table>
         <p style="font-size:12px;color:var(--text-muted);margin-top:16px;text-align:center">
-            Full coverage available for all 50 states + DC, PR, and territories. Table shows top 10 by enrollment.
+            13,679 districts across 55 jurisdictions &mdash; 50 states, DC and four territories. Table shows top 10 by enrollment.
             <br>Coverage improves daily as our scraper processes remaining districts.
         </p>
     </section>
@@ -888,7 +888,7 @@
                 <p class="price-desc">The full dataset. Every district, every state. For national-scale operations.</p>
                 <a href="mailto:fred@hazeydata.ai?subject=SSD%20National%20Access&body=I'm%20interested%20in%20the%20School%20Schedule%20Database%20(national).%0A%0ACompany:%20%0AUse%20case:%20" class="price-cta primary">Contact Sales</a>
                 <ul class="price-features">
-                    <li><span class="check">✓</span> All 13,400+ districts nationwide</li>
+                    <li><span class="check">✓</span> All 13,679 districts nationwide</li>
                     <li><span class="check">✓</span> JSON + CSV API access</li>
                     <li><span class="check">✓</span> Daily data updates</li>
                     <li><span class="check">✓</span> NCES IDs for easy joins</li>

--- a/ssd/_variants/a.html
+++ b/ssd/_variants/a.html
@@ -84,9 +84,9 @@
 
   <section class="hero" style="padding-top:64px">
     <div>
-      <span class="pill"><span class="dot"></span> Updated daily · 13,400+ districts</span>
+      <span class="pill"><span class="dot"></span> Actively Growing — Three School Years</span>
       <h1>Know when <em>every</em> school in America is on break.</h1>
-      <p class="lede">Day-level calendar data for all 50 states + DC. Spring break, winter break, summer — structured, scored, and ready for your demand model.</p>
+      <p class="lede">Day-level calendar data for 13,679 districts across 55 jurisdictions. Spring break, winter break, summer — structured, scored, and ready for your demand model.</p>
       <div class="cta">
         <button class="btn" onclick="document.getElementById('p').scrollIntoView({behavior:'smooth'})" data-ab="api">Get API access — $99/mo</button>
         <!-- Download-sample CTA hidden pending R1 clean-sample regen (S54) - see data-hub ticket -->
@@ -107,10 +107,10 @@
   </section>
 
   <div class="metrics">
-    <div class="metric"><div class="n a">13,400+</div><div class="l">Districts</div></div>
+    <div class="metric"><div class="n a">13,679</div><div class="l">Districts</div></div>
 
   
-    <div class="metric"><div class="n">46M+</div><div class="l">Students</div></div>
+    <div class="metric"><div class="n">44.7M</div><div class="l">Students</div></div>
     <div class="metric"><div class="n">50 + DC</div><div class="l">States</div></div>
     <div class="metric"><div class="n">3 yrs</div><div class="l">2024–2027</div></div>
   </div>

--- a/ssd/_variants/b.html
+++ b/ssd/_variants/b.html
@@ -95,9 +95,9 @@
 
   <section class="hero">
     <div>
-      <span class="tag"><span class="dot"></span> Live · updated daily</span>
+      <span class="tag"><span class="dot"></span> Actively Growing — Three School Years</span>
       <h1>Know when <span class="g">every school</span> in America is on break.</h1>
-      <p class="lede">Day-level calendar data for 13,400+ districts. Every day classified, every cell confidence-scored. Built for demand models that move with families.</p>
+      <p class="lede">Day-level calendar data for 13,679 districts. Every day classified, every cell confidence-scored. Built for demand models that move with families.</p>
       <div class="cta">
         <button class="btn primary" onclick="document.getElementById('p').scrollIntoView({behavior:'smooth'})" data-ab="api">Get API access — $99/mo</button>
         <!-- Download-sample CTA hidden pending R1 clean-sample regen (S54) - see data-hub ticket -->
@@ -121,8 +121,8 @@
   </section>
 
   <div class="strip">
-    <div class="m"><div class="n a">13,400+</div><div class="l">Districts</div></div>
-    <div class="m"><div class="n">46M+</div><div class="l">Students</div></div>
+    <div class="m"><div class="n a">13,679</div><div class="l">Districts</div></div>
+    <div class="m"><div class="n">44.7M</div><div class="l">Students</div></div>
     <div class="m"><div class="n">50 + DC</div><div class="l">States covered</div></div>
     <div class="m"><div class="n">365×3</div><div class="l">Days × school years</div></div>
   </div>
@@ -146,14 +146,14 @@
     <h2>RESTful JSON or CSV. Dead simple.</h2>
     <p class="sub">Query by district, date, or state. Every row carries a confidence score and source method.</p>
     <div class="codewrap">
-      <div class="ch mono">GET /api/v1/days?district_id=FL_12000306&date=2026-03-27</div>
+      <div class="ch mono">GET https://api.hazeydata.ai/ssd/v1/days?district_id=FL_1201440&amp;date=2026-11-25</div>
       <pre class="mono">{
-  <span class="k">"district"</span>: <span class="s">"Alachua County"</span>,
+  <span class="k">"district"</span>: <span class="s">"ORANGE"</span>,
   <span class="k">"state"</span>: <span class="s">"FL"</span>,
-  <span class="k">"date"</span>: <span class="s">"2026-03-27"</span>,
+  <span class="k">"date"</span>: <span class="s">"2026-11-25"</span>,
   <span class="k">"is_in_session"</span>: <span class="s">0.0</span>,
   <span class="k">"day_type"</span>: <span class="s">"BREAK"</span>,
-  <span class="k">"break_name"</span>: <span class="s">"Spring Break"</span>,
+  <span class="k">"break_name"</span>: <span class="s">"Thanksgiving Break"</span>,
   <span class="k">"confidence"</span>: <span class="s">0.95</span>,
   <span class="k">"source_method"</span>: <span class="s">"observed"</span>
 }</pre>
@@ -168,7 +168,7 @@
       <div class="pleft">
         <div style="font-weight:600;font-size:17px">Full access</div>
         <ul>
-          <li>All 13,400+ districts nationwide</li>
+          <li>All 13,679 districts in the store</li>
           <li>All 3 school years (2024–2027)</li>
           <li>Day-level rows (365 per district / year)</li>
           <li>Full API access — JSON + CSV</li>

--- a/ssd/index.html
+++ b/ssd/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>US School Calendar Database — 13,400 Districts, Day-Level Data | HazeyData</title>
-    <meta name="description" content="Complete US school calendar dataset. 13,400+ districts, 46M+ students. Day-level data with confidence scoring. API access $99/mo.">
+    <title>US School Calendar Database — 13,679 Districts, Day-Level Data | HazeyData</title>
+    <meta name="description" content="Complete US school calendar dataset. 13,679 districts, 44.7M students. Day-level data with confidence scoring. API access $99/mo.">
     <link rel="icon" type="image/png" sizes="32x32" href="../assets/icon-32.png">
     <link rel="apple-touch-icon" sizes="180x180" href="../assets/icon-180.png">
     <meta name="theme-color" content="#0a1628">
     <link rel="canonical" href="https://hazeydata.ai/ssd/">
     <meta property="og:type" content="product">
     <meta property="og:url" content="https://hazeydata.ai/ssd/">
-    <meta property="og:title" content="US School Calendar Database — 13,400 Districts, Day-Level Data | HazeyData">
-    <meta property="og:description" content="Complete US school calendar dataset. 13,400+ districts, 46M+ students. Day-level data with confidence scoring. API access $99/mo.">
+    <meta property="og:title" content="US School Calendar Database — 13,679 Districts, Day-Level Data | HazeyData">
+    <meta property="og:description" content="Complete US school calendar dataset. 13,679 districts, 44.7M students. Day-level data with confidence scoring. API access $99/mo.">
     <meta property="og:image" content="https://hazeydata.ai/assets/ssd-og-card.svg">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@disneystatswhiz">
-    <meta name="twitter:title" content="US School Calendar Database — 13,400 Districts, Day-Level Data | HazeyData">
-    <meta name="twitter:description" content="Complete US school calendar dataset. 13,400+ districts, 46M+ students. Day-level data with confidence scoring. API access $99/mo.">
+    <meta name="twitter:title" content="US School Calendar Database — 13,679 Districts, Day-Level Data | HazeyData">
+    <meta name="twitter:description" content="Complete US school calendar dataset. 13,679 districts, 44.7M students. Day-level data with confidence scoring. API access $99/mo.">
     <meta name="twitter:image" content="https://hazeydata.ai/assets/ssd-og-card.svg">
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
@@ -149,9 +149,9 @@
     </header>
 
     <section class="hero" style="padding-bottom:20px;">
-        <div class="hero-badge"><span class="dot"></span> Actively Growing -- Updated Daily</div>
+        <div class="hero-badge"><span class="dot"></span> Actively Growing -- Three School Years</div>
         <h1>Know When Every School in America Is on Break</h1>
-        <p>Day-level school calendar data for 13,400+ districts, 46M+ students. API access for demand forecasting, travel planning, and market research.</p>
+        <p>Day-level school calendar data for 13,679 districts, 44.7M students. API access for demand forecasting, travel planning, and market research.</p>
     </section>
 
     <section class="heatmap-section" id="heatmap" style="padding-top:10px;">
@@ -213,8 +213,8 @@
             </template>
         </div>
         <div class="hero-stats" style="margin-bottom:0;">
-            <div class="hero-stat"><div class="val">13,400+</div><div class="lbl">Districts</div></div>
-            <div class="hero-stat"><div class="val">46M+</div><div class="lbl">Students</div></div>
+            <div class="hero-stat"><div class="val">13,679</div><div class="lbl">Districts</div></div>
+            <div class="hero-stat"><div class="val">44.7M</div><div class="lbl">Students</div></div>
             <div class="hero-stat"><div class="val">50</div><div class="lbl">States + DC</div></div>
             <div class="hero-stat"><div class="val">3 Years</div><div class="lbl">2024-2027</div></div>
         </div>
@@ -226,10 +226,10 @@
         <h2 class="section-title">Data Quality</h2>
         <p class="section-sub">What you're actually getting -- no hedging, no asterisks.</p>
         <div class="quality-list">
-            <div class="quality-item"><div class="quality-icon check">&#10003;</div><div class="quality-text"><h4>All 50 states + DC covered.</h4><p>Day-level rows for every district, every day, across three school years. Filter by confidence to match your risk tolerance &mdash; see Confidence Scores below.</p></div></div>
+            <div class="quality-item"><div class="quality-icon check">&#10003;</div><div class="quality-text"><h4>55 jurisdictions covered.</h4><p>Day-level rows for 13,679 districts across three school years. Filter on <code>source_method</code>. The evidence methods are <code>observed</code>, <code>r1_extract_driver</code>, <code>official_calendar_pdf_verified</code> and <code>human_anchor_email</code>; every other method is an estimate. Do not filter on <code>confidence</code> &mdash; it does not separate evidence from estimate, and the highest confidence values in the store belong to estimate methods.</p></div></div>
             <div class="quality-item"><div class="quality-icon check">&#10003;</div><div class="quality-text"><h4>Every day has a classification.</h4><p>365 rows per district per year. Each day is classified: in-session, weekend, holiday, spring break, winter break, summer, etc. No gaps.</p></div></div>
-            <div class="quality-item"><div class="quality-icon check">&#10003;</div><div class="quality-text"><h4>Every cell has a confidence score.</h4><p>0.0 to 1.0 per cell. You decide your threshold. Filter by confidence to match your risk tolerance.</p></div></div>
-            <div class="quality-item"><div class="quality-icon info">i</div><div class="quality-text"><h4>Active data quality program.</h4><p>We're continuously auditing source provenance and tightening confidence scores. Filter on <code>confidence</code> to match your tolerance &mdash; higher-confidence rows are hand-verified or directly extracted from district sources.</p></div></div>
+            <div class="quality-item"><div class="quality-icon check">&#10003;</div><div class="quality-text"><h4>Every cell has a confidence score.</h4><p>0.0 to 1.0 per cell. Confidence ranks certainty <em>within</em> a method; it does not rank methods against each other. Filter on <code>source_method</code>. The evidence methods are <code>observed</code>, <code>r1_extract_driver</code>, <code>official_calendar_pdf_verified</code> and <code>human_anchor_email</code>; every other method is an estimate. Do not filter on <code>confidence</code> &mdash; it does not separate evidence from estimate, and the highest confidence values in the store belong to estimate methods.</p></div></div>
+            <div class="quality-item"><div class="quality-icon info">i</div><div class="quality-text"><h4>Active data quality program.</h4><p>We're continuously auditing source provenance and tightening confidence scores. Filter on <code>source_method</code>. The evidence methods are <code>observed</code>, <code>r1_extract_driver</code>, <code>official_calendar_pdf_verified</code> and <code>human_anchor_email</code>; every other method is an estimate. Do not filter on <code>confidence</code> &mdash; it does not separate evidence from estimate, and the highest confidence values in the store belong to estimate methods.</p></div></div>
             <div class="quality-item full-width"><div class="quality-icon check">&#10003;</div><div class="quality-text"><h4>Three school years available.</h4><p>2024-2025, 2025-2026, and 2026-2027. Historical context for year-over-year analysis, plus forward-looking data for planning.</p></div></div>
         </div>
     </section>
@@ -254,14 +254,14 @@
 
     <section class="section">
         <h2 class="section-title">Coverage</h2>
-        <p class="section-sub">Day-level rows for every public school district in the United States.</p>
+        <p class="section-sub">Day-level rows for 13,679 districts across three school years.</p>
         <div class="coverage-summary">
             <div class="coverage-stats">
-                <div class="coverage-stat"><div class="val">13,400+</div><div class="lbl">Districts</div></div>
-                <div class="coverage-stat"><div class="val">46M+</div><div class="lbl">Students</div></div>
-                <div class="coverage-stat"><div class="val">50 + DC</div><div class="lbl">States</div></div>
+                <div class="coverage-stat"><div class="val">13,679</div><div class="lbl">Districts</div></div>
+                <div class="coverage-stat"><div class="val">44.7M</div><div class="lbl">Students</div></div>
+                <div class="coverage-stat"><div class="val">55</div><div class="lbl">Jurisdictions</div></div>
             </div>
-            <p class="coverage-note">Every public school district in the US is represented with day-level rows across three school years. NCES IDs on every row for easy joins to Census, NCES, and other federal datasets. Confidence scores on every cell let you filter to high-quality rows for your use case.</p>
+            <p class="coverage-note">13,679 districts are represented with day-level rows across three school years, every date labelled with the method it came from. NCES IDs on every row for easy joins to Census, NCES, and other federal datasets. Confidence scores on every cell let you filter to high-quality rows for your use case.</p>
         </div>
     </section>
 
@@ -283,7 +283,7 @@
         <p class="section-sub">RESTful JSON or CSV. Day-level queries by district, date, state. Dead simple. <a href="/ssd/docs.html" style="color:var(--accent);text-decoration:none;">Read the full docs &rarr;</a></p>
         <div class="code-block">
             <span class="comment"># Query a single district on a specific date</span><br>
-            GET <span class="string">/api/v1/days?district_id=FL_1200030&amp;date=2026-03-27</span><br><br>
+            GET <span class="string">https://api.hazeydata.ai/ssd/v1/days?district_id=FL_1201440&amp;date=2026-11-25</span><br><br>
             <span class="comment"># Response</span><br>
             {<br>
             &nbsp;&nbsp;<span class="key">"district"</span>: <span class="string">"Alachua County"</span>,<br>
@@ -299,7 +299,7 @@
         </div>
         <div class="code-block">
             <span class="comment"># Download full CSV for a state</span><br>
-            curl <span class="string">"https://hazeydata.ai/api/v1/days?state=FL&amp;format=csv"</span> \<br>
+            curl <span class="string">"https://api.hazeydata.ai/ssd/v1/days?state=FL&amp;format=csv"</span> \<br>
             &nbsp;&nbsp;-H <span class="string">"Authorization: Bearer ssd_live_your_key_here"</span> \<br>
             &nbsp;&nbsp;-o florida_school_days.csv
         </div>
@@ -319,7 +319,7 @@
                 </div>
                 <button onclick="subscribe()" class="price-cta primary" id="subscribe-btn">Get Started</button>
                 <ul class="price-features">
-                    <li><span class="check">&#10003;</span> All 13,400+ districts nationwide</li>
+                    <li><span class="check">&#10003;</span> All 13,679 districts nationwide</li>
                     <li><span class="check">&#10003;</span> All 3 school years (2024-2027)</li>
                     <li><span class="check">&#10003;</span> Day-level data (365 rows per district per year)</li>
                     <li><span class="check">&#10003;</span> Full API access (JSON + CSV)</li>
@@ -415,9 +415,9 @@
             var notIn = dayData.not_in_session_students || 0;
             var pct = dayData.national_pct || 0;
             if (notIn > 0) {
-                pctLabel.textContent = (notIn / 1000000).toFixed(1) + 'M students not in session (' + Math.round(100 - pct) + '% of 46M)';
+                pctLabel.textContent = (notIn / 1000000).toFixed(1) + 'M students not in session (' + Math.round(100 - pct) + '% of 44.7M)';
             } else {
-                pctLabel.textContent = Math.round(pct) + '% of 46M students in session';
+                pctLabel.textContent = Math.round(pct) + '% of 44.7M students in session';
             }
         }
 


### PR DESCRIPTION
## What changed and why

Corrects the SSD product pages on `hazeydata.ai` — the acquisition surface `#64` never
reached. Tracked as **hazeydata/SSD-2.0#112**.

**AC-1 changed the scope, so it goes first.**

## AC-1 — what is actually served

All four URLs return **200**. `/ssd/` and `/ssd.html` each **rotate between two payloads**,
16,822 and 19,148 bytes — measured over 16 fetches, both sizes appearing at both URLs.

Each is **exactly 537 bytes larger** than `ssd/_variants/a.html` (16,285 deployed) and
`b.html` (18,611). **So the served pages are the two variants plus an injected wrapper**, and:

| file | served? |
|---|---|
| `ssd/_variants/a.html` | **yes** — the light payload |
| `ssd/_variants/b.html` | **yes** — the dark payload |
| `ssd/index.html` (54 KB) | **no** |
| `ssd.html` (44 KB) | **no** |

**Both large files are unserved, not just `ssd/index.html`.** Neither is reachable at any of
the four URLs. **Nothing deleted** (NG-6).

## AC-2 — satisfied, and re-measured before any edit

**The confidence-filter advice appears in 0 of 18 served payloads** — 16 fetches across both
URLs plus both variant files directly. `filter by confidence`, `Filter on confidence` and
`risk tolerance` all return zero.

**So AC-2 as filed describes a defect no buyer can reach**, exactly as re-scoped. The two
unserved files are corrected anyway, reusing `llms.txt`'s wording **verbatim** (NG-7):

> Filter on `source_method`. The evidence methods are `observed`, `r1_extract_driver`,
> `official_calendar_pdf_verified` and `human_anchor_email`; every other method is an
> estimate. Do not filter on `confidence` — it does not separate evidence from estimate, and
> the highest confidence values in the store belong to estimate methods.

The third quote — *"higher-confidence rows are hand-verified or directly extracted"* — is
replaced wholesale, since it is a false provenance claim rather than bad advice.

## AC-3 — the priority, re-queried immediately before committing

Was: `GET /api/v1/days?district_id=FL_12000306&date=2026-03-27` — wrong host, wrong path,
**malformed district id**.

Now: `GET https://api.hazeydata.ai/ssd/v1/days?district_id=FL_1201440&date=2026-11-25`

**Queried against D1 at edit time, not copied from the issue:**

```
district_id  FL_1201440     date        2026-11-25     school_year  2026-2027
day_type     BREAK          break_name  Thanksgiving Break
confidence   0.95           source_method  observed    is_in_session  0
district_name  ORANGE  (dim_district, enrollment 206,815)
```

The page's JSON body now matches that row **field for field**.

## AC-4 · AC-5 · AC-6

- **AC-4** — `Updated daily · 13,400+ districts`, `Live · updated daily` and
  `Actively Growing — Updated Daily` → **`Actively Growing — Three School Years`**. No
  freshness synonym (NG-4).
- **AC-5**, re-derived at edit time: **13,679 districts** — the issue's 13,703 is six days old
  and the count has **fallen** — **44.7M students**, **55 jurisdictions**. Corrected in text,
  in the **three meta/OG/Twitter title tags**, and in **`updateCounter`'s two `% of 46M`
  branches**, which the issue correctly warned a text-only pass would miss.
- **AC-6** — *"Every public school district in the US is represented"* and *"All 50 states +
  DC covered"* → 13,679 districts, three school years, every date labelled with the method it
  came from.

**Applied to both served variants** — they rotate in lockstep, so correcting one leaves
roughly half of production impressions wrong (`F-45`).

## AC-7 — every surface checked, including the clean ones

**14,163 SSD files scanned** (`ssd/**`, `ssd.html`), which is far more surface than the issue
anticipated — `ssd/districts/` alone holds a per-district page for most of the store.

**After this change, retired claims survive in four files, none of them a product page:**

| file | carries | live? |
|---|---|---|
| **`ssd/blog/us-school-calendar-dataset.html`** | **`risk tolerance`, `/api/v1/days`** | **200 — yes** |
| `ssd/blog/july-4th-theme-park-crowds.html` | `46M` | yes |
| `ssd/us-districts.json` | `13,400` | data file, not a claim |
| `ssd/docs.html` | `markitdown_extraction` | out of scope — `#97`/`#121` |

**The blog post is the one worth your attention: it is live, indexed, and carries the same
dead API example AC-3 exists to fix.** Not edited here — AC-7 is a reporting criterion and the
blog was not in AC-2/AC-3's scope. **Recommend a follow-up issue.**

**`ssd/states/california/` JSON-LD**, the copy `C-14` says everyone misses:

```json
"@type": "Dataset",
"name": "California School Calendar Data 2025-2026",
"description": "Complete school calendar data for 993 California districts covering 4.7M students.",
"dateModified": "2026-06-14"
```

**Two problems, reported not fixed:** D1 serves **989** California districts, not 993; and
*"Complete"* is the same overclaim AC-6 removes from the product pages. **It is served (200)
and search engines quote it.** There are 50+ sibling state pages with the same template.

`ssd/explorer.html`, `ssd/dashboard.html`, `ssd/success.html` and the remaining blog posts:
**clean**.

## Non-goals preserved

NG-1 TPCR untouched · NG-2 `schoolschedulesdatabase.com`, `llms.txt`, `api-docs.html`
untouched · **NG-3 text and numbers only — 48 insertions, 48 deletions, perfectly balanced;
no restyle or reflow** · NG-4 no freshness claim · NG-5 pricing, `$99`, toggle, trial and
Stripe paths untouched · NG-6 no `_variants` deleted · NG-7 `llms.txt` wording verbatim ·
NG-8 no widening into `F-22`, `#35` or the address gap.

## AC-8 — verification after deploy

**Not yet possible: a merge is not a deploy.** After this merges and deploys, re-run:

```
curl -sL https://hazeydata.ai/ssd/ | grep -Ei '13,400|46M|updated daily|/api/v1/days'   # expect 0
curl -sL https://hazeydata.ai/ssd.html | grep -Ei '13,400|46M|updated daily'            # expect 0
curl -sL "https://api.hazeydata.ai/ssd/v1/days?district_id=FL_1201440&date=2026-11-25"
```

**Fetch each URL several times** — they rotate, and one fetch samples one variant.

## Risk

**Low-medium.** Text and numbers on live product pages, including the page that takes
payment; no structural, pricing or checkout change. The one judgement call worth flagging:
**13,679 includes 314 districts whose ids are malformed** (`_0`–`_5`, `00`, `39`, `9a`, `da`)
— they are in the store and queryable, so the figure is what the product serves, but if you
want the stricter 13,365 say so and I will change it. That is `#35`'s territory (NG-8).

Refs hazeydata/SSD-2.0#112
